### PR TITLE
chore: remove Google Workspace MCP servers from connected-mcp sample

### DIFF
--- a/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/.env.example
+++ b/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/.env.example
@@ -8,7 +8,7 @@ AUTH0_CLIENT_ID="{yourClientId}"
 AUTH0_CLIENT_SECRET="{yourClientSecret}"
 
 # Comma-separated list of MCP servers to enable.
-# Available: notion, github, linear, atlassian, cloudflare, sentry, asana, slack, salesforce, snowflake, hubspot, gmail, gcalendar, gdrive
+# Available: notion, github, linear, atlassian, cloudflare, sentry, asana, slack, salesforce, snowflake, hubspot
 ENABLED_MCP_SERVERS="notion"
 
 # Required when snowflake is enabled — no default URL.

--- a/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/README.md
+++ b/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how an AI agent can call **remote [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers** on the user's behalf without the agent ever holding the user's credentials for those services.
 
-It ships with fourteen pre-configured MCP servers: **Notion**, **GitHub**, **Gmail**, **Google Calendar**, **Google Drive**, **Slack**, **Atlassian**, **HubSpot**, **Asana**, **Linear**, **Salesforce**, **Snowflake**, **Sentry**, and **Cloudflare**. The same pattern extends to any OAuth 2.0-protected MCP server.
+It ships with eleven pre-configured MCP servers: **Notion**, **GitHub**, **Slack**, **Atlassian**, **HubSpot**, **Asana**, **Linear**, **Salesforce**, **Snowflake**, **Sentry**, and **Cloudflare**. The same pattern extends to any OAuth 2.0-protected MCP server.
 
 The agent authenticates to each MCP server with a short-lived access token that Auth0 mints from the user's **Connected Account** via [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). The first time the user invokes a tool for a given service, they're prompted to connect that account; after that, the agent transparently exchanges the user's Auth0 refresh token for a federated access token and presents it as a `Bearer` token to the MCP server.
 
@@ -57,9 +57,6 @@ Set `ENABLED_MCP_SERVERS` to a comma-separated list of connection names to enabl
 | ------------- | --------------------- | --------------------------- |
 | `notion`      | `NOTION_MCP_URL`      | [Notion](#notion)           |
 | `github`      | `GITHUB_MCP_URL`      | [GitHub](#github)           |
-| `gmail`       | `GMAIL_MCP_URL`       | [Google Workspace](#google-workspace-gmail-calendar-drive) |
-| `gcalendar`   | `GCALENDAR_MCP_URL`   | [Google Workspace](#google-workspace-gmail-calendar-drive) |
-| `gdrive`      | `GDRIVE_MCP_URL`      | [Google Workspace](#google-workspace-gmail-calendar-drive) |
 | `slack`       | `SLACK_MCP_URL`       | [Slack](#slack)             |
 | `atlassian`   | `ATLASSIAN_MCP_URL`   | [Atlassian](#atlassian)     |
 | `hubspot`     | `HUBSPOT_MCP_URL`     | [HubSpot](#hubspot)         |
@@ -170,55 +167,6 @@ curl --request POST \
     "authentication": {"active": false}
   }'
 ```
-
-
-### Google Workspace (Gmail, Calendar, Drive)
-
-Gmail, Google Calendar, and Google Drive each have their own MCP server but share a single OAuth client and Auth0 connection.
-
-**1. Complete the GCP setup** by following the [Google Workspace MCP server setup guide](https://developers.google.com/workspace/guides/configure-mcp-servers):
-
-- Enable the **Workspace MCP API** and the individual **Gmail MCP API**, **Google Drive MCP API**, and **Google Calendar MCP API** in your GCP project.
-- Configure the OAuth consent screen and add any test users who will connect.
-- Create an **OAuth 2.0 client ID** (Web application type) with `https://YOUR_AUTH0_DOMAIN/login/callback` as an authorized redirect URI.
-
-Note the **Client ID** and **Client Secret**.
-
-**2. Get a Management API access token**. See the Notion section above for instructions.
-
-**3. Create the Auth0 connection:**
-
-```bash
-curl --request POST \
-  --url "https://$DOMAIN/api/v2/connections" \
-  --header "authorization: Bearer $TOKEN" \
-  --header 'content-type: application/json' \
-  --data '{
-    "name": "google-workspace",
-    "strategy": "google-oauth2",
-    "options": {
-      "client_id": "<GOOGLE_CLIENT_ID>",
-      "client_secret": "<GOOGLE_CLIENT_SECRET>",
-      "email": true,
-      "profile": true,
-      "gmail_readonly": true,
-      "drive_readonly": true,
-      "calendar_read": true,
-      "calendar_events_readonly": true
-    },
-    "enabled_clients": ["<YOUR_APP_CLIENT_ID>"],
-    "connected_accounts": {"active": true},
-    "authentication": {"active": false}
-  }'
-```
-
-**4. Enable the servers in `.env.local`:**
-
-```
-ENABLED_MCP_SERVERS=gmail,gcalendar,gdrive
-```
-
-The MCP URLs default to the standard Google endpoints. Override them with `GMAIL_MCP_URL`, `GCALENDAR_MCP_URL`, or `GDRIVE_MCP_URL` only if needed.
 
 
 ### Slack

--- a/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/src/integrations/mcp/servers.test.ts
+++ b/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/src/integrations/mcp/servers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { loadMcpServers, NOTION_MCP_SERVER, GITHUB_MCP_SERVER, LINEAR_MCP_SERVER, ATLASSIAN_MCP_SERVER, CLOUDFLARE_MCP_SERVER, SENTRY_MCP_SERVER, ASANA_MCP_SERVER, SLACK_MCP_SERVER, SALESFORCE_MCP_SERVER, SNOWFLAKE_MCP_SERVER, HUBSPOT_MCP_SERVER, GMAIL_MCP_SERVER, GCALENDAR_MCP_SERVER, GDRIVE_MCP_SERVER } from './servers';
+import { loadMcpServers, NOTION_MCP_SERVER, GITHUB_MCP_SERVER, LINEAR_MCP_SERVER, ATLASSIAN_MCP_SERVER, CLOUDFLARE_MCP_SERVER, SENTRY_MCP_SERVER, ASANA_MCP_SERVER, SLACK_MCP_SERVER, SALESFORCE_MCP_SERVER, SNOWFLAKE_MCP_SERVER, HUBSPOT_MCP_SERVER } from './servers';
 
 describe('loadMcpServers', () => {
   it('defaults to Notion only when ENABLED_MCP_SERVERS is not set', () => {
@@ -18,10 +18,10 @@ describe('loadMcpServers', () => {
 
   it('loads all servers when all connection names are listed', () => {
     const servers = loadMcpServers({
-      ENABLED_MCP_SERVERS: 'notion,github,linear,atlassian,cloudflare,sentry,asana,slack,salesforce,snowflake,hubspot,gmail,gcalendar,gdrive',
+      ENABLED_MCP_SERVERS: 'notion,github,linear,atlassian,cloudflare,sentry,asana,slack,salesforce,snowflake,hubspot',
       SNOWFLAKE_MCP_URL: 'https://myorg-myaccount.snowflakecomputing.com/api/v2/databases/DB/schemas/PUBLIC/mcp-servers/MY_MCP',
     });
-    expect(servers).toHaveLength(14);
+    expect(servers).toHaveLength(11);
     expect(servers).toContainEqual(NOTION_MCP_SERVER);
     expect(servers).toContainEqual(GITHUB_MCP_SERVER);
     expect(servers).toContainEqual(LINEAR_MCP_SERVER);
@@ -32,15 +32,12 @@ describe('loadMcpServers', () => {
     expect(servers).toContainEqual(SLACK_MCP_SERVER);
     expect(servers).toContainEqual(SALESFORCE_MCP_SERVER);
     expect(servers).toContainEqual(HUBSPOT_MCP_SERVER);
-    expect(servers).toContainEqual(GMAIL_MCP_SERVER);
-    expect(servers).toContainEqual(GCALENDAR_MCP_SERVER);
-    expect(servers).toContainEqual(GDRIVE_MCP_SERVER);
   });
 
   it('pairs each server with an Auth0 connection used for the Token Vault exchange', () => {
     const snowflakeUrl = 'https://myorg-myaccount.snowflakecomputing.com/api/v2/databases/DB/schemas/PUBLIC/mcp-servers/MY_MCP';
-    const [notion, github, linear, atlassian, cloudflare, sentry, asana, slack, salesforce, snowflake, hubspot, gmail, gcalendar, gdrive] = loadMcpServers({
-      ENABLED_MCP_SERVERS: 'notion,github,linear,atlassian,cloudflare,sentry,asana,slack,salesforce,snowflake,hubspot,gmail,gcalendar,gdrive',
+    const [notion, github, linear, atlassian, cloudflare, sentry, asana, slack, salesforce, snowflake, hubspot] = loadMcpServers({
+      ENABLED_MCP_SERVERS: 'notion,github,linear,atlassian,cloudflare,sentry,asana,slack,salesforce,snowflake,hubspot',
       SNOWFLAKE_MCP_URL: snowflakeUrl,
     });
     expect(notion.connection).toBe('notion');
@@ -65,12 +62,6 @@ describe('loadMcpServers', () => {
     expect(snowflake.url).toBe(snowflakeUrl);
     expect(hubspot.connection).toBe('hubspot');
     expect(hubspot.url).toBe('https://mcp.hubspot.com');
-    expect(gmail.connection).toBe('google-workspace');
-    expect(gmail.url).toBe('https://gmailmcp.googleapis.com/mcp/v1');
-    expect(gcalendar.connection).toBe('google-workspace');
-    expect(gcalendar.url).toBe('https://calendarmcp.googleapis.com/mcp/v1');
-    expect(gdrive.connection).toBe('google-workspace');
-    expect(gdrive.url).toBe('https://drivemcp.googleapis.com/mcp/v1');
   });
 
   it('lets the Notion server URL be overridden via env without touching the connection', () => {
@@ -158,33 +149,6 @@ describe('loadMcpServers', () => {
     });
     expect(servers[0].url).toBe('https://mcp.hubspot.test');
     expect(servers[0].connection).toBe('hubspot');
-  });
-
-  it('lets the Gmail server URL be overridden via env without touching the connection', () => {
-    const servers = loadMcpServers({
-      ENABLED_MCP_SERVERS: 'gmail',
-      GMAIL_MCP_URL: 'https://gmailmcp.googleapis.test/mcp/v1',
-    });
-    expect(servers[0].url).toBe('https://gmailmcp.googleapis.test/mcp/v1');
-    expect(servers[0].connection).toBe('google-workspace');
-  });
-
-  it('lets the Google Calendar server URL be overridden via env without touching the connection', () => {
-    const servers = loadMcpServers({
-      ENABLED_MCP_SERVERS: 'gcalendar',
-      GCALENDAR_MCP_URL: 'https://calendarmcp.googleapis.test/mcp/v1',
-    });
-    expect(servers[0].url).toBe('https://calendarmcp.googleapis.test/mcp/v1');
-    expect(servers[0].connection).toBe('google-workspace');
-  });
-
-  it('lets the Google Drive server URL be overridden via env without touching the connection', () => {
-    const servers = loadMcpServers({
-      ENABLED_MCP_SERVERS: 'gdrive',
-      GDRIVE_MCP_URL: 'https://drivemcp.googleapis.test/mcp/v1',
-    });
-    expect(servers[0].url).toBe('https://drivemcp.googleapis.test/mcp/v1');
-    expect(servers[0].connection).toBe('google-workspace');
   });
 
   it('requires SNOWFLAKE_MCP_URL since Snowflake has no default URL', () => {

--- a/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/src/integrations/mcp/servers.ts
+++ b/call-apis-on-users-behalf/others-api/connected-mcp-vercel-ai-next-js/src/integrations/mcp/servers.ts
@@ -82,24 +82,6 @@ export const HUBSPOT_MCP_SERVER: McpServerConfig = {
   scopes: [],
 };
 
-export const GMAIL_MCP_SERVER: McpServerConfig = {
-  connection: 'google-workspace',
-  url: 'https://gmailmcp.googleapis.com/mcp/v1',
-  scopes: [],
-};
-
-export const GCALENDAR_MCP_SERVER: McpServerConfig = {
-  connection: 'google-workspace',
-  url: 'https://calendarmcp.googleapis.com/mcp/v1',
-  scopes: [],
-};
-
-export const GDRIVE_MCP_SERVER: McpServerConfig = {
-  connection: 'google-workspace',
-  url: 'https://drivemcp.googleapis.com/mcp/v1',
-  scopes: [],
-};
-
 const ALL_MCP_SERVERS: Record<string, McpServerConfig> = {
   notion: NOTION_MCP_SERVER,
   github: GITHUB_MCP_SERVER,
@@ -112,9 +94,6 @@ const ALL_MCP_SERVERS: Record<string, McpServerConfig> = {
   salesforce: SALESFORCE_MCP_SERVER,
   snowflake: SNOWFLAKE_MCP_SERVER,
   hubspot: HUBSPOT_MCP_SERVER,
-  gmail: GMAIL_MCP_SERVER,
-  gcalendar: GCALENDAR_MCP_SERVER,
-  gdrive: GDRIVE_MCP_SERVER,
 };
 
 const URL_OVERRIDES: Record<string, string> = {
@@ -129,9 +108,6 @@ const URL_OVERRIDES: Record<string, string> = {
   salesforce: 'SALESFORCE_MCP_URL',
   snowflake: 'SNOWFLAKE_MCP_URL',
   hubspot: 'HUBSPOT_MCP_URL',
-  gmail: 'GMAIL_MCP_URL',
-  gcalendar: 'GCALENDAR_MCP_URL',
-  gdrive: 'GDRIVE_MCP_URL',
 };
 
 type Env = Record<string, string | undefined>;


### PR DESCRIPTION
Removing Google Workspace MCP from the connected-mcp sample. These integrations are not ready for a public sample yet; will re-add once generally available.